### PR TITLE
Fix for navigation highlight

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,9 +9,11 @@ highlighter: rouge
 repo_url: https://github.com/GSA/ficam-federation
 baseurl: '/ficam-federation'
 branch: federalist-pages
+
 # Federalist overwrites the site.branch value when deploying
 # the site.branch was used in dynamic link generation for objects like Edit Page
 # we want the dynamic links to send users to the staging branch.  Adding new site variable to ensure federalist doesn't overwrite.
+editbranch: staging
 
 # Links
 # List links that you would like to appear on the top navigation bar here

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,11 +1,12 @@
-{% assign current = page.url | downcase | split: '/' %}
+{% assign current = page.url | downcase | remove: '/' %}
 
 <aside class="sidenav" id="menu-content">
   <nav>
     <ul class="usa-sidenav-list">
       {% for link in site.navigation %}
-          <li class="group {% if page.title == link.text %}usa-current-section{% endif %}">
-            <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}" title="{{ link.text }}">{{ link.text }}</a>
+          {% assign navUrl = link.url | strip %}
+          <li class="group{% if navUrl == current %} usa-current-section{% endif %}">
+            <a href="{% if link.internal == true %}{{ site.baseurl }}/{% endif %}{{ link.url }}" title="{{ page.title }}">{{ link.text }}</a>
           
           {% if link.coll == true %}
           <button class="usa-sidenav-expand_subnav"


### PR DESCRIPTION
This is a fix for the nav bar not highlighted when the page title does not match the navigation title. The url was used instead to compare.